### PR TITLE
Allow HTML_CodeSniffer to be placed in custom elements and have custom issue details

### DIFF
--- a/Auditor/HTMLCSAuditor.js
+++ b/Auditor/HTMLCSAuditor.js
@@ -822,7 +822,7 @@ var HTMLCSAuditor = new function()
             var msgElementSource       = document.createElement('div');
             msgElementSource.className = _prefix + 'issue-source';
             msgDiv.appendChild(msgElementSource);
-            _options.customIssueSource.call(this, id, message, standard, msgElementSource);
+            _options.customIssueSource.call(this, id, message, standard, msgElementSource, msgDetailsDiv);
         } else if (message.element.outerHTML) {
             var preText  = '';
             var postText = '';


### PR DESCRIPTION
These changes allow HTML_CodeSniffer to have custom parent element so that it does not get added to the document.body by default. There is also a new setting that allows external script to provide custom content for the issue source section using callbacks.

New settings are:
- noHeader: If true then no header element will be added to the Auditor (this is the title bar, drag handle etc).
- parentElement: The parent element Auditor is going to be placed in to.
- customIssueSource: A callback method that will be called when issue's source panel is being created.
