### PR TITLE
Resolve SC 4.1.2 issues with Accessibility API values (technique H91)

### DIFF
--- a/Standards/WCAG2AAA/Sniffs/Principle4/Guideline4_1/4_1_2.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle4/Guideline4_1/4_1_2.js
@@ -226,8 +226,14 @@ var HTMLCS_WCAG2AAA_Sniffs_Principle4_Guideline4_1_4_1_2 = {
             }
         } else if (requiredValue === 'option_selected') {
             // Select lists need a selected Option element.
-            var selected = element.querySelector('option[selected]');
-            if (selected !== null) {
+            if (element.hasAttribute('multiple') === false) {
+                var selected = element.querySelector('option[selected]');
+                if (selected !== null) {
+                    valueFound = true;
+                }
+            } else {
+                // Allow zero element selection to be valid where the SELECT
+                // element has been declared as a multiple selection.
                 valueFound = true;
             }
         } else if (requiredValue.charAt(0) === '@') {


### PR DESCRIPTION
- Text input fields where the value attribute is absent shouldn't be treated as a missing API value, since HTML 4 declares the attribute as "implied" and thus, effectively has an empty value. This is considered legal by technique H91 (see example 3b).
- Select elements should now be allowed to have zero elements selected if they are set "multiple". If they are single, a selected option must still be set, because HTML 4 declares the implementation of an empty selection as explicitly undefined.
