### PR TITLE
Fix Issue Tracker link in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,7 +12,7 @@ HTML_CodeSniffer comes with standards and sniffs that cover the three conformanc
 
 ## Contributing and reporting issues
 
-To report any issues with using HTML_CodeSniffer, please use the [HTML_CodeSniffer Issue Tracker](http://squizlabs.github.com/HTML_CodeSniffer/).
+To report any issues with using HTML_CodeSniffer, please use the [HTML_CodeSniffer Issue Tracker](http://squizlabs.github.com/HTML_CodeSniffer/issues).
 
 Contributions to the HTML_CodeSniffer code base are also welcome: please create a fork of the main repository, then submit your modified code through a [Pull Request](http://help.github.com/send-pull-requests/) for review. A Pull Request also automatically creates an issue in the Issue Tracker, so if you have code to contribute, you do not need to do both.
 


### PR DESCRIPTION
Pardon me, copy-pasted the link from the bottom paragraph without changing the link.
