### PR TITLE
Fix issue in run method exposed by PR #11

### DIFF
--- a/HTMLCS.js
+++ b/HTMLCS.js
@@ -84,9 +84,11 @@ var HTMLCS = new function()
      * @return void
      */
     this.run = function(callback, content) {
-        var element = null;
+        var element      = null;
+        var loadingFrame = false;
         if (typeof content === 'string') {
             if (this.isFullDoc(content) === true) {
+                loadingFrame = true;
                 var elementFrame = document.createElement('iframe');
                 elementFrame.style.display = 'none';
                 elementFrame = document.body.insertBefore(elementFrame, null);
@@ -127,7 +129,7 @@ var HTMLCS = new function()
         elements.unshift(element);
 
         // Run the sniffs.
-        if (this.isFullDoc(content) === false) {
+        if (loadingFrame === false) {
             _run(elements, element, callback);
         }
     };


### PR DESCRIPTION
Pull Request #11 changed the definition of a full document to include being sent the document object, not just the document element of said object. This broke the bookmarklet - spinning without returning anything.

In HTMLCS.run, if a source code check contains a full document, it is loaded into an iframe and a _run() call occurs on the onload event. In other cases, and also , the _run() occurs at the end of the method.

The problem was, full documents that weren't source did not have _run() called at all. Since PR #11 counts Document objects as full docs now, the first _run() didn't get called because it wasn't source, but the second was simply based on "is this not a full doc" and therefore wasn't getting run either.

This pull implements this better, as a switch that only gets turned on when the appropriate section of code runs.
