### PR TITLE
Change "long description" message in SC 1.1.1 from warning to notice

### DIFF
--- a/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_1/1_1_1.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_1/1_1_1.js
@@ -165,7 +165,7 @@ var HTMLCS_WCAG2AAA_Sniffs_Principle1_Guideline1_1_1_1_1 = {
      */
     testLongdesc: function(element)
     {
-        HTMLCS.addMessage(HTMLCS.NOTICE, element, 'If this image cannot be fully described in a short text alternative, ensure a long text alternative is available, such as in the body text or through a link.', 'G73,G74');
+        HTMLCS.addMessage(HTMLCS.NOTICE, element, 'If this image cannot be fully described in a short text alternative, ensure a long text alternative is also available, such as in the body text or through a link.', 'G73,G74');
 
     },
 


### PR DESCRIPTION
Requests have been made for a change to the following message in Success Criterion 1.1.1:

> **Warning:** If this image cannot be described in a short text alternative, ensure a long text alternative is available, such as in the body text or through a link. (G73, G74)

This is currently generated for all images. There is an argument that this should be downgraded to a Notice, as HTML_CodeSniffer cannot automatically check for the absence of a long description - since it can hide as just general body text or a normal link. Other checks of this type, where we apply to most or all elements of a certain type, are typically emitted as a Notice.

This Pull Request changes the above message from a Warning to a Notice. It also adds extra wording so it doesn't sound like a short text alternative is optional when a long one is used.
