### PR TITLE
Fix IE8 bug with issue handling in Auditor for iframe document elements

### DIFF
--- a/Auditor/HTMLCSAuditor.js
+++ b/Auditor/HTMLCSAuditor.js
@@ -1381,9 +1381,9 @@ var HTMLCSAuditor = new function()
                 if (wrapper) {
                     if (wrapper === _messages[i].element) {
                         ignore = true;
-                    } else if (document === _messages[i].element) {
-                        // Don't ignore document. This is to short-circuit calls to
-                        // contains() because IE doesn't like document being the argument.
+                    } else if (_messages[i].element.documentElement) {
+                        // Short-circuit document objects. IE doesn't like documents
+                        // being the argument of contains() calls.
                         ignore = false;
                     } else if ((wrapper.contains) && (wrapper.contains(_messages[i].element) === true)) {
                         ignore = true;


### PR DESCRIPTION
Fix an IE8 error in cases where the element affected is a document object, but not the top-level document.

We already have a short-circuit for the top-level document (as IE does not like document objects being the parameter of a contains call) but this doesn't work for frames. Instead, check for a defined documentElement property.
