### PR TITLE
Resolve IE8 frame-related bug when closing the auditor

### DIFF
--- a/Auditor/HTMLCSAuditor.js
+++ b/Auditor/HTMLCSAuditor.js
@@ -1447,7 +1447,7 @@ var HTMLCSAuditor = new function()
             var wrapper = _doc.getElementById('HTMLCS-wrapper');
 
             if (wrapper) {
-                _doc.querySelector('body').removeChild(wrapper);
+                wrapper.parentNode.removeChild(wrapper);
 
                 var pointerEl = pointer.pointer;
                 if (pointerEl && pointerEl.parentNode) {


### PR DESCRIPTION
Pretty much as said on the tin. There were some cases when testing a framed site when IE8 would throw an error when closing the auditor. Resolving by using the parent node of the wrapper when removing the node, rather than the document's body.
