### PR TITLE
Form controls with title attributes should not throw missing-ID errors

### DIFF
--- a/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_3/1_3_1.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_3/1_3_1.js
@@ -179,7 +179,14 @@ var HTMLCS_WCAG2AAA_Sniffs_Principle1_Guideline1_3_1_3_1 = {
 
         if ((element.hasAttribute('id') === false) && (isNoLabelControl === false)) {
             // There is no id attribute at all on the control.
-            HTMLCS.addMessage(HTMLCS.ERROR, element, 'Form control does not have an ID, therefore it cannot have an explicit label.', 'H44.NoId');
+            if (element.hasAttribute('title') === true) {
+                if (/^\s*$/.test(element.getAttribute('title')) === true) {
+                    // But the title attribute is empty. Whoops.
+                    HTMLCS.addMessage(HTMLCS.ERROR, element, 'Form control without a label contains an empty title attribute. The title attribute should identify the purpose of the control.', 'H65.3');
+                }
+            } else {
+                HTMLCS.addMessage(HTMLCS.ERROR, element, 'Form control does not have an ID, therefore it cannot have an explicit label.', 'H44.NoId');
+            }//end if
         } else {
             var id = element.getAttribute('id');
             if (!this._labelNames[id]) {


### PR DESCRIPTION
When a form control contains no ID attribute, previously it would always emit an error message about "not having an ID, therefore cannot have an explicit label" under Success Criterion 1.3.1.

If it also has a non-empty title attribute (using [technique H65](http://www.w3.org/TR/WCAG20-TECHS/H65)), the relevant Success Criterion would be fulfilled for this field, and thus the missing-ID error would not be appropriate to throw.

This pull changes the interpretation of the form control label code to be consistent with the above explanation.
