### PR TITLE
Fix paging bugs for single page screens

### DIFF
--- a/Auditor/HTMLCSAuditor.js
+++ b/Auditor/HTMLCSAuditor.js
@@ -400,7 +400,9 @@ var HTMLCSAuditor = new function()
 
         if (issue === 1) {
             prevButton.className += ' disabled';
-        } else if (issue === totalIssues) {
+        }
+
+        if (issue === totalIssues) {
             nextButton.className += ' disabled';
         }
 
@@ -957,7 +959,10 @@ var HTMLCSAuditor = new function()
                 }
             }
 
-            next.className    = next.className.replace(new RegExp(' ' + _prefix + 'disabled'), '');
+            if (totalPages > 1) {
+                next.className = next.className.replace(new RegExp(' ' + _prefix + 'disabled'), '');
+            }
+
             pageNum.innerHTML = 'Page ' + _page + ' of ' + totalPages;
 
             var issueList = _doc.querySelectorAll('.HTMLCS-issue-list')[0];
@@ -972,7 +977,10 @@ var HTMLCSAuditor = new function()
                 }
             }
 
-            prev.className    = prev.className.replace(new RegExp(' ' + _prefix + 'disabled'), '');
+            if (totalPages > 1) {
+                prev.className = prev.className.replace(new RegExp(' ' + _prefix + 'disabled'), '');
+            }
+
             pageNum.innerHTML = 'Page ' + _page + ' of ' + totalPages;
 
             var issueList = _doc.querySelectorAll('.HTMLCS-issue-list')[0];


### PR DESCRIPTION
Two cosmetic issues were identified with the Auditor, which have been fixed thus:
- When there is one page of results (5 or less issues), when you click on one (disabled) arrow, the opposite arrow becomes enabled.
  - Fixed: the disabled arrows were presuming that when one arrow is clicked the other must enable. Not the case with there is only one page of results.
- When there is one detail result ("1 of 1"), the next arrow remains enabled.
  - Fixed: the code put the "should the previous or next page button be disabled" question in an if-else if block, therefore incorrectly assuming that both could not be disabled at the same time.
