### PR TITLE
All text with background images should ignore any solid background colour; throw warnings on contrast ratio tests

### DIFF
--- a/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_4/1_4_3.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_4/1_4_3.js
@@ -66,7 +66,7 @@ var HTMLCS_WCAG2AAA_Sniffs_Principle1_Guideline1_4_1_4_3 = {
 
                 if (hasBgImg === true) {
                     code += '.BgImage';
-                    HTMLCS.addMessage(HTMLCS.WARNING, element, 'This element\'s text is placed on a background image, but no solid background colour is available. Ensure the contrast ratio between the text and all covered parts of the image are at least ' + required + ':1.' + recommendText, code);
+                    HTMLCS.addMessage(HTMLCS.WARNING, element, 'This element\'s text is placed on a background image. Ensure the contrast ratio between the text and all covered parts of the image are at least ' + required + ':1.', code);
                 } else {
                     code += '.Fail';
                     HTMLCS.addMessage(HTMLCS.ERROR, element, 'This element has insufficient contrast at this conformance level. Expected a contrast ratio of at least ' + required + ':1, but text in this element has a contrast ratio of ' + value + ':1.' + recommendText, code);

--- a/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_4/1_4_3_Contrast.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_4/1_4_3_Contrast.js
@@ -86,21 +86,22 @@ var HTMLCS_WCAG2AAA_Sniffs_Principle1_Guideline1_4_1_4_3_Contrast = {
                             parent = parent.parentNode;
                         }//end while
 
-                        // If the background colour is still transparent, this is probably
-                        // a fragment with which we cannot reliably make a statement about
-                        // contrast ratio. Skip the element.
-                        if ((bgColour === 'transparent') || (bgColour === 'rgba(0, 0, 0, 0)')) {
-                            if (hasBgImg === true) {
-                                failures.push({
-                                    element: node,
-                                    colour: style.color,
-                                    bgColour: undefined,
-                                    value: undefined,
-                                    required: reqRatio,
-                                    hasBgImage: true
-                                });
-                            }
-
+                        if (hasBgImg === true) {
+                            // If we have a background image, skip the contrast ratio checks,
+                            // and push a warning instead.
+                            failures.push({
+                                element: node,
+                                colour: style.color,
+                                bgColour: undefined,
+                                value: undefined,
+                                required: reqRatio,
+                                hasBgImage: true
+                            });
+                            continue;
+                        } else if ((bgColour === 'transparent') || (bgColour === 'rgba(0, 0, 0, 0)')) {
+                            // If the background colour is still transparent, this is probably
+                            // a fragment with which we cannot reliably make a statement about
+                            // contrast ratio. Skip the element.
                             continue;
                         }
 

--- a/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_4/1_4_6.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_4/1_4_6.js
@@ -66,7 +66,7 @@ var HTMLCS_WCAG2AAA_Sniffs_Principle1_Guideline1_4_1_4_6 = {
 
                 if (hasBgImg === true) {
                     code += '.BgImage';
-                    HTMLCS.addMessage(HTMLCS.WARNING, element, 'This element\'s text is placed on a background image, but no solid background colour is available. Ensure the contrast ratio between the text and all covered parts of the image are at least ' + required + ':1.' + recommendText, code);
+                    HTMLCS.addMessage(HTMLCS.WARNING, element, 'This element\'s text is placed on a background image. Ensure the contrast ratio between the text and all covered parts of the image are at least ' + required + ':1.', code);
                 } else {
                     code += '.Fail';
                     HTMLCS.addMessage(HTMLCS.ERROR, element, 'This element has insufficient contrast at this conformance level. Expected a contrast ratio of at least ' + required + ':1, but text in this element has a contrast ratio of ' + value + ':1.' + recommendText, code);


### PR DESCRIPTION
If a background image takes priority over a solid background colour, and is not defined in the same element, the background colour may not be representative of the actual colour the image has. For instance, with no solid background colour defined, text may be compared against a white background defined on the body tag. This is not desirable.
