### PR TITLE
Elements without style causing runtime error in SC 2.2.2

### DIFF
--- a/Standards/WCAG2AAA/Sniffs/Principle2/Guideline2_2/2_2_2.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle2/Guideline2_2/2_2_2.js
@@ -44,8 +44,10 @@ var HTMLCS_WCAG2AAA_Sniffs_Principle2_Guideline2_2_2_2_2 = {
             for (var i = 0; i < elements.length; i++) {
                 var computedStyle = HTMLCS.util.style(elements[i]);
 
-                if (/blink/.test(computedStyle['text-decoration']) === true) {
-                    HTMLCS.addMessage(HTMLCS.WARNING, elements[i], 'Ensure there is a mechanism available to stop this blinking element in less than five seconds.', 'F4');
+                if (computedStyle) {
+                    if (/blink/.test(computedStyle['text-decoration']) === true) {
+                        HTMLCS.addMessage(HTMLCS.WARNING, elements[i], 'Ensure there is a mechanism available to stop this blinking element in less than five seconds.', 'F4');
+                    }
                 }
             }//end for
         } else if (element.nodeName.toLowerCase() === 'blink') {


### PR DESCRIPTION
Fix issues raised by certain sites that have unusual frames, to the point where this Success Criterion's tests for blinking elements was failing due to a complete lack of computed style. This failure only occurred in Firefox.

A common example was sites using Twitter's provided "Tweet button", which was creating a hidden, sourceless inline frame (interpreted as about:blank by browsers), and this was causing this test to trip on its html element.
