### PR TITLE
IE fixes.

### DIFF
--- a/Auditor/HTMLCSAuditor.css
+++ b/Auditor/HTMLCSAuditor.css
@@ -74,6 +74,7 @@
     cursor: pointer;
     height: 2.2em;
     opacity: 0.5;
+    filter: alpha(opacity=50);
     right: 0;
     top: 0;
     width: 2.2em;
@@ -81,6 +82,7 @@
 
 #HTMLCS-wrapper .HTMLCS-close:hover {
     opacity: 1;
+    filter: none;
 }
 
 #HTMLCS-wrapper .HTMLCS-close:after {
@@ -165,6 +167,7 @@
 
 #HTMLCS-wrapper .HTMLCS-lineage .HTMLCS-lineage-item:first-child span {
     opacity: 0;
+    filter: alpha(opacity=0);
     position: absolute;
     left: -9999px;
     width: 0;
@@ -655,6 +658,7 @@
 
 #HTMLCS-wrapper .HTMLCS-checkbox.disabled {
     opacity: 0.4;
+    filter: alpha(opacity=40);
     cursor: default;
 }
 
@@ -794,6 +798,7 @@
 
 .HTMLCS-pointer-hidden {
     opacity: 0;
+    filter: alpha(opacity=0);
     display: none;
 }
 
@@ -859,11 +864,13 @@
 #HTMLCS-wrapper.HTMLCS-processing #HTMLCS-settings-view-report,
 #HTMLCS-wrapper #HTMLCS-settings-view-report.disabled {
     cursor: default;
+    filter: alpha(opacity=40);
     opacity: 0.4;
 }
 
 #HTMLCS-wrapper .HTMLCS-button.disabled {
     cursor: default;
+    filter: alpha(opacity=30);
     opacity: 0.3;
 }
 

--- a/Auditor/HTMLCSAuditor.js
+++ b/Auditor/HTMLCSAuditor.js
@@ -65,8 +65,6 @@ var HTMLCSAuditor = new function()
             checked = false;
         }
 
-        var isIE = new RegExp('msie', 'i').test(navigator.userAgent);
-
         var label   = _doc.createElement('label');
         var content = '';
         label.className = _prefix + 'checkbox';
@@ -90,7 +88,10 @@ var HTMLCSAuditor = new function()
         label.innerHTML = content;
 
         var input = label.getElementsByTagName('input')[0];
-        input.onclick = function() {
+
+        label.onclick = function(event) {
+            input.checked = !input.checked;
+
             if (input.checked === true) {
                 label.className += ' active';
             } else {
@@ -100,12 +101,8 @@ var HTMLCSAuditor = new function()
             if (onclick instanceof Function === true) {
                 onclick(input);
             }
-        };
 
-        if (isIE === true) {
-            label.onclick = function() {
-                input.click();
-            }
+            return false;
         }
 
         return label;


### PR DESCRIPTION
1. IE9+ had issues with toggling the level switches. There was code to fix weird behaviour in IE8 (due, I now find, to IE8's reluctance to fire events on hidden inputs) but it applied to all of IE. Replaced the browser sniff with something else.
2. Some opacity CSS weren't applied to IE8 (ie. no alpha filter equivalent to some opacity styles).
