### PR TITLE
Fix false positive with inputs with no ID where the input type is not lowercase

### DIFF
--- a/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_3/1_3_1.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_3/1_3_1.js
@@ -173,7 +173,7 @@ var HTMLCS_WCAG2AAA_Sniffs_Principle1_Guideline1_3_1_3_1 = {
         }
 
         var isNoLabelControl = false;
-        if (/^(submit|reset|image|hidden|button)$/.test(inputType) === true) {
+        if (/^(submit|reset|image|hidden|button)$/.test(inputType.toLowerCase()) === true) {
             isNoLabelControl = true;
         }
 


### PR DESCRIPTION
A test for whether an input required a label (eg. if hidden or button) was case sensitive, so was providing false "this has no ID therefore cannot have an explicit label" messages on inputs with types like "Submit" and "Hidden". Although lowercase is best practice, recognise other cases.
