### PR TITLE
Fix disabled level switches and View Report button on the landing page of the Auditor

### DIFF
--- a/Auditor/HTMLCSAuditor.css
+++ b/Auditor/HTMLCSAuditor.css
@@ -692,6 +692,10 @@
   background-color: #205caf;
 }
 
+#HTMLCS-wrapper .HTMLCS-checkbox.disabled * {
+  cursor: default;
+}
+
 #HTMLCS-wrapper .HTMLCS-checkbox-slider {
   -moz-transition: left 0.2s ease-out;
   -webkit-transition: left 0.2s ease-out;

--- a/Auditor/HTMLCSAuditor.js
+++ b/Auditor/HTMLCSAuditor.js
@@ -90,17 +90,19 @@ var HTMLCSAuditor = new function()
         var input = label.getElementsByTagName('input')[0];
 
         label.onclick = function(event) {
-            input.checked = !input.checked;
+            if (disabled === false) {
+                input.checked = !input.checked;
 
-            if (input.checked === true) {
-                label.className += ' active';
-            } else {
-                label.className = label.className.replace('active', '');
-            }
+                if (input.checked === true) {
+                    label.className += ' active';
+                } else {
+                    label.className = label.className.replace('active', '');
+                }
 
-            if (onclick instanceof Function === true) {
-                onclick(input);
-            }
+                if (onclick instanceof Function === true) {
+                    onclick(input);
+                }
+            }//end if
 
             return false;
         }
@@ -578,6 +580,7 @@ var HTMLCSAuditor = new function()
                 var disabled = false;
 
                 if (msgCount === 0) {
+                    checked  = false;
                     disabled = true;
                 }
             }
@@ -602,7 +605,7 @@ var HTMLCSAuditor = new function()
                 }
 
                 if (enable === true) {
-                    viewReportDiv.className = viewReportDiv.className.replace(/ disabled/, '');
+                    viewReportDiv.className = viewReportDiv.className.replace(/ disabled/g, '');
                 } else {
                     viewReportDiv.className += ' disabled';
                 }
@@ -1398,6 +1401,8 @@ var HTMLCSAuditor = new function()
                 if (ignore === true) {
                     _messages.splice(i, 1);
                     i--;
+                } else {
+                    console.info([_messages[i].element, _messages[i].code]);
                 }
             }//end for
 


### PR DESCRIPTION
This relates to a situation where there were no instances of one or more levels of messages (eg. no errors).

Disabled switches could still be selected, and this resulted in multiple instances of the "disabled" class appearing on the View Report button. Only one of these was being removed each time a combination existed that could enable it.

Therefore if there was a situation where, eg. with no errors, if you turned off warnings, then errors, two disabled classes would be added. If you then enable notices, it would not remove all disabled classes until either other switch was switched back on.

Provide better feedback for disabled level switches (it now appears off and unswitchable) - which should avoid the possibility of doubled disabled classes in the first place - and also fix the regex that removes the disabled class.
