### PR TITLE
Add ability to ignore certain message codes using ignoreMsgCodes auditor run option

### DIFF
--- a/Auditor/HTMLCSAuditor.js
+++ b/Auditor/HTMLCSAuditor.js
@@ -1356,6 +1356,10 @@ var HTMLCSAuditor = new function()
             _options.includeCss = true;
         }
 
+        if (_options.ignoreMsgCodes === undefined) {
+            _options.ignoreMsgCodes = [];
+        }
+
         this.includeCss('HTMLCS');
 
         var target    = _doc.getElementById(_prefix + 'wrapper');
@@ -1398,11 +1402,16 @@ var HTMLCSAuditor = new function()
                     }
                 }//end if
 
+                for (var j = 0; j < options.ignoreMsgCodes.length; j++) {
+                    if (new RegExp(options.ignoreMsgCodes[j]).test(_messages[i].code) === true) {
+                        ignore = true;
+                        break;
+                    }
+                }
+
                 if (ignore === true) {
                     _messages.splice(i, 1);
                     i--;
-                } else {
-                    console.info([_messages[i].element, _messages[i].code]);
                 }
             }//end for
 


### PR DESCRIPTION
This option is an array containing RegExp objects (or strings interpreted as RegExp's); if any is matched it will be excluded.

eg.
To remove colour contrast-related errors (in SC 1.4.3, 1.4.6) you could do this:

```
var options = {
    ignoreMsgCodes: [
        /Guideline1_4\.1_4_3/,
        /Guideline1_4\.1_4_6/
    ]
};
HTMLCSAuditor.run('WCAG2AAA', source, options);
```
