### PR TITLE
Messages from "_top" sniffs now replayed in DOM order.

### DIFF
--- a/HTMLCS.js
+++ b/HTMLCS.js
@@ -222,6 +222,7 @@ var HTMLCS = new function()
      * @param {Function} [callback] The function to call once all tests are run.
      */
     var _run = function(elements, topElement, callback) {
+        var topMsgs = [];
         while (elements.length > 0) {
             var element = elements.shift();
 
@@ -231,8 +232,25 @@ var HTMLCS = new function()
                 var tagName = element.tagName.toLowerCase();
             }
 
+            // First check whether any "top" messages need to be shifted off for this
+            // element. If so, dump off into the main messages.
+            for (var i = 0; i < topMsgs.length;) {
+                if (element === topMsgs[i].element) {
+                    _messages.push(topMsgs[i]);
+                    topMsgs.splice(i, 1);
+                } else {
+                    i++;
+                }
+            }//end for
+
             if (_tags[tagName] && _tags[tagName].length > 0) {
                 _processSniffs(element, _tags[tagName].concat([]), topElement);
+
+                // Save "top" messages, and reset the messages array.
+                if (tagName === '_top') {
+                    topMsgs   = _messages;
+                    _messages = [];
+                }
             }
         }//end while
 


### PR DESCRIPTION
Messages from "_top" sniffs are now saved and replayed when the element is found in the DOM order.

This reduces as much as possible (does not eliminate) the amount of bouncing up and down the page - as used to happen when the "_top" sniffs (which could emit messages anywhere) fire, resulting in the first few messages being ordered by sniff (and thus in the WCAG 2.0 case, by Success Criterion). This now saves and clears "_top" messages and replays them into the message list when it is time to handle that element.

It will not entirely eliminate bouncing because elements that are absolute-positioned out of the page order will cause bouncing, but for most elements it should cause the pointer to flow naturally.
