### PR TITLE
Enhance user feedback for issues that HTML_CodeSniffer can not visually point to

### DIFF
--- a/Auditor/HTMLCSAuditor.js
+++ b/Auditor/HTMLCSAuditor.js
@@ -824,11 +824,10 @@ var HTMLCSAuditor = new function()
                 msg = 'This message relates to the entire document and thus cannot be pointed to.';
             } else {
                 var body = message.element.ownerDocument.getElementsByTagName('body')[0];
-                if (HTMLCS.util.contains(body, message.element) === false) {
-                    //
-                    msg = 'This message relates to an element outside of the document body, and thus cannot be pointed to.';
-                } else if (HTMLCS.util.isInDocument(message.element) === false) {
+                if (HTMLCS.util.isInDocument(message.element) === false) {
                     msg += ' It may have been removed from the document since the report was generated.';
+                } else if (HTMLCS.util.contains(body, message.element) === false) {
+                    msg = 'This message relates to an element outside of the document body, and thus cannot be pointed to.';
                 } else {
                     msg += ' It may be hidden from view using styles.';
                 }


### PR DESCRIPTION
This adds a message (currently in-between the code snippet and the main part of the box) stating why the element couldn't be pointed to.

These conditions are currently displayed:
- The message element is the document object.
- The element is no longer in the document (eg. removed using DHTML).
- The element is outside the body (eg. messages relating to link elements at AAA level).
- The element is hidden from view using styles.
