### PR TITLE
SC 3.2.2: Automatic submission on input should be a warning, not error

### DIFF
--- a/Standards/WCAG2AAA/Sniffs/Principle3/Guideline3_2/3_2_2.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle3/Guideline3_2/3_2_2.js
@@ -52,7 +52,7 @@ var HTMLCS_WCAG2AAA_Sniffs_Principle3_Guideline3_2_3_2_2 = {
         var submitButton = form.querySelector('input[type=submit], input[type=image], button[type=submit]');
 
         if (submitButton === null) {
-            HTMLCS.addMessage(HTMLCS.ERROR, form, 'Form does not contain a submit button (input type="submit", input type="image", or button type="submit").', 'H32.2');
+            HTMLCS.addMessage(HTMLCS.WARNING, form, 'If this form submits automatically on inputting of a field, ensure the user is informed. Otherwise, add a submit button (input type="submit", input type="image", or button type="submit").', 'H32.2');
         }
     }
 };


### PR DESCRIPTION
On Input submissions are allowed if the user is told beforehand - therefore, this error should be changed to a warning.

If the user is not told beforehand (preferably in the form), the author should manually fail the form.
