### PR TITLE
Revert Pull #41

### DIFF
--- a/Standards/WCAG2AAA/Sniffs/Principle3/Guideline3_2/3_2_2.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle3/Guideline3_2/3_2_2.js
@@ -52,7 +52,7 @@ var HTMLCS_WCAG2AAA_Sniffs_Principle3_Guideline3_2_3_2_2 = {
         var submitButton = form.querySelector('input[type=submit], input[type=image], button[type=submit]');
 
         if (submitButton === null) {
-            HTMLCS.addMessage(HTMLCS.WARNING, form, 'If this form submits automatically on inputting of a field, ensure the user is informed. Otherwise, add a submit button (input type="submit", input type="image", or button type="submit").', 'H32.2');
+            HTMLCS.addMessage(HTMLCS.ERROR, form, 'Form does not contain a submit button (input type="submit", input type="image", or button type="submit").', 'H32.2');
         }
     }
 };


### PR DESCRIPTION
This related to changing the H32 test in SC 3.2.2 from an error to a warning, on the premise of "if the user is advised of the automatic behaviour...".

This is getting reverted; there are good arguments against disallowing automatic submission, even when advised (see http://www.w3.org/TR/WCAG20-TECHS/F36).
