### PR TITLE
IE8 fix in cases where the Auditor is placed in a container that includes invalid HTML

### DIFF
--- a/Auditor/HTMLCSAuditor.js
+++ b/Auditor/HTMLCSAuditor.js
@@ -1005,7 +1005,8 @@ var HTMLCSAuditor = new function()
                 next.className = next.className.replace(new RegExp(' ' + _prefix + 'disabled'), '');
             }
 
-            pageNum.innerHTML = 'Page ' + _page + ' of ' + totalPages;
+            pageNum.innerHTML = '';
+            pageNum.appendChild(document.createTextNode('Page ' + _page + ' of ' + totalPages));
 
             var issueList = _doc.querySelectorAll('.HTMLCS-issue-list')[0];
             issueList.style.marginLeft = ((_page - 1) * -300) + 'px';
@@ -1023,7 +1024,8 @@ var HTMLCSAuditor = new function()
                 prev.className = prev.className.replace(new RegExp(' ' + _prefix + 'disabled'), '');
             }
 
-            pageNum.innerHTML = 'Page ' + _page + ' of ' + totalPages;
+            pageNum.innerHTML = '';
+            pageNum.appendChild(document.createTextNode('Page ' + _page + ' of ' + totalPages));
 
             var issueList = _doc.querySelectorAll('.HTMLCS-issue-list')[0];
             issueList.style.marginLeft = ((_page - 1) * -300) + 'px';


### PR DESCRIPTION
Such as nested forms.

Apparently using innerHTML in IE8 (once element is placed in document) is fraught with danger for "Unknown runtime error" issues in cases of invalid HTML. Using DOM manipulation to change the label instead.
