### PR TITLE
IE8 opacity fixes for pointer and translucent auditor

### DIFF
--- a/Auditor/HTMLCSAuditor.css
+++ b/Auditor/HTMLCSAuditor.css
@@ -46,6 +46,11 @@
     z-index: 100000;
 }
 
+#HTMLCS-wrapper.HTMLCS-translucent {
+    opacity: 0.5;
+    filter: alpha(opacity=50);
+}
+
 #HTMLCS-wrapper strong {
     font-weight: bold;
 }

--- a/Auditor/HTMLCSAuditor.js
+++ b/Auditor/HTMLCSAuditor.js
@@ -1968,9 +1968,9 @@ var HTMLCSAuditor = new function()
             ) {
                 var self = this;
 
-                this.container.style.opacity = 0.5;
+                this.container.className += ' HTMLCS-translucent';
                 setTimeout(function() {
-                    self.container.style.opacity = 1;
+                    self.container.className = self.container.className.replace('HTMLCS-translucent', '');
                 }, 4000);
             }
 


### PR DESCRIPTION
Fixing a couple of issues where the opacity style was added in javascript:
- Hiding the pointer when determining whether the pointer can be used, and
- Making the auditor translucent when the issue being pointed to is underneath the auditor.

...but the IE8 filter style was not added either. Replaced both with styles that are added and removed as appropriate.
