### PR TITLE
Fix link border around Fork Me ribbon on IE

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -152,7 +152,7 @@ td a:hover {
  transition:all 1.0s ease-in-out;
 }
 
-#git img:a {
+#git img {
     border:none;
 }
 
@@ -1087,8 +1087,8 @@ only screen and (   min--moz-device-pixel-ratio: 2),
 only screen and (     -o-min-device-pixel-ratio: 2/1),
 only screen and (        min-device-pixel-ratio: 2),
 only screen and (                min-resolution: 192dpi),
-only screen and (                min-resolution: 2dppx) { 
-    
+only screen and (                min-resolution: 2dppx) {
+
     #bookmarklet-feature {
         background: url(../images/bookmarklet-feature@2x.png) 72px 30px no-repeat;
         background-size: 318px 307px;


### PR DESCRIPTION
There was a rule in the home page CSS that was meant to remove a link border around the "fork me" ribbon, but it did not work on IE.
