### PR TITLE
Add some more reset styles to auditor

### DIFF
--- a/Auditor/HTMLCSAuditor.css
+++ b/Auditor/HTMLCSAuditor.css
@@ -4,7 +4,6 @@
 #HTMLCS-wrapper * {
     margin: 0;
     padding: 0;
-    font-family: Arial,Sans Serif;
     float: none;
     height: inherit;
     height: auto;
@@ -19,6 +18,7 @@
 #HTMLCS-wrapper li, #HTMLCS-wrapper table {
     background: transparent;
     color: black;
+    font-family: Arial,Sans Serif;
 }
 
 #HTMLCS-wrapper a,
@@ -489,7 +489,6 @@
 }
 
 #HTMLCS-wrapper .HTMLCS-issue-source-inner strong {
-    font-family: Monaco, monospace;
     font-weight: normal;
     color: #FFF;
 }


### PR DESCRIPTION
Add colour (foreground and background) to text container type elements within the auditor. It's only on certain elements, because it would not be correct to apply them to certain elements such as input fields.

Also moved the font family property to this new rule. This fixes the issue with the reset style overriding the font on the "current element" part of the code snippet.
