### PR TITLE
Fix reporting issue with contrast ratio (Issue #89)

### DIFF
--- a/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_4/1_4_3.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_4/1_4_3.js
@@ -39,11 +39,19 @@ var HTMLCS_WCAG2AAA_Sniffs_Principle1_Guideline1_4_1_4_3 = {
 
             for (var i = 0; i < failures.length; i++) {
                 var element   = failures[i].element;
-                var value     = (Math.round(failures[i].value * 100) / 100);
+                
+                var decimals  = 2;
+                var value     = (Math.round(failures[i].value * Math.pow(10, decimals)) / Math.pow(10, decimals));
                 var required  = failures[i].required;
                 var recommend = failures[i].recommendation;
                 var hasBgImg  = failures[i].hasBgImage || false;
 
+                // If the values would look identical, add decimals to the value.
+                while (required === value) {
+                    decimals++;
+                    value = (Math.round(failures[i].value * Math.pow(10, decimals)) / Math.pow(10, decimals));
+                }
+                
                 if (required === 4.5) {
                     var code = 'G18';
                 } else if (required === 3.0) {

--- a/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_4/1_4_6.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_4/1_4_6.js
@@ -39,10 +39,18 @@ var HTMLCS_WCAG2AAA_Sniffs_Principle1_Guideline1_4_1_4_6 = {
 
             for (var i = 0; i < failures.length; i++) {
                 var element   = failures[i].element;
-                var value     = (Math.round(failures[i].value * 100) / 100);
+                
+                var decimals  = 2;
+                var value     = (Math.round(failures[i].value * Math.pow(10, decimals)) / Math.pow(10, decimals));
                 var required  = failures[i].required;
                 var recommend = failures[i].recommendation;
                 var hasBgImg  = failures[i].hasBgImage || false;
+
+                // If the values would look identical, add decimals to the value.
+                while (required === value) {
+                    decimals++;
+                    value = (Math.round(failures[i].value * Math.pow(10, decimals)) / Math.pow(10, decimals));
+                }
 
                 if (required === 4.5) {
                     var code = 'G18';


### PR DESCRIPTION
Where we know the contrast ratio check has failed but 2 decimals isn't enough to distinguish, add more decimals until it's different.
