### PR TITLE
A title is a valid name for a <a> in H91

### DIFF
--- a/Standards/WCAG2AAA/Sniffs/Principle4/Guideline4_1/4_1_2.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle4/Guideline4_1/4_1_2.js
@@ -131,7 +131,7 @@ var HTMLCS_WCAG2AAA_Sniffs_Principle4_Guideline4_1_4_1_2 = {
                     }
                 }//end if
             } else {
-                if (/^\s*$/.test(content) === true && element.hasAttribute(title) === false) {
+                if (nameFound === false) {
                     // Href provided, but no content or title.
                     // We only fire this message when there are no images in the content.
                     // A link around an image with no alt text is already covered in SC


### PR DESCRIPTION
This is to fix links with no text content from failing `[Standard].Principle4.Guideline4_1.4_1_2.H91.A.NoContent` when a title attribute is present, as described by http://www.w3.org/TR/WCAG20-TECHS/H91
