### PR TITLE
Mark contrast errors with alpha transparency as warnings

### DIFF
--- a/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_4/1_4_3.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_4/1_4_3.js
@@ -45,6 +45,7 @@ var HTMLCS_WCAG2AAA_Sniffs_Principle1_Guideline1_4_1_4_3 = {
                 var required  = failures[i].required;
                 var recommend = failures[i].recommendation;
                 var hasBgImg  = failures[i].hasBgImage || false;
+                var bgColour   = failures[i].bgColour || false;
 
                 // If the values would look identical, add decimals to the value.
                 while (required === value) {
@@ -72,7 +73,10 @@ var HTMLCS_WCAG2AAA_Sniffs_Principle1_Guideline1_4_1_4_3 = {
                     recommendText = ' Recommendation: change ' + recommendText.join(', ') + '.';
                 }
 
-                if (hasBgImg === true) {
+                if (bgColour && bgColour.indexOf('rgba') === 0) {
+                    code += '.Alpha';
+                    HTMLCS.addMessage(HTMLCS.WARNING, element, 'This element\'s text is placed on a background that has an alpha transparency. Ensure the contrast ratio between the text and background color are at least ' + required + ':1.', code);
+                } else if (hasBgImg === true) {
                     code += '.BgImage';
                     HTMLCS.addMessage(HTMLCS.WARNING, element, 'This element\'s text is placed on a background image. Ensure the contrast ratio between the text and all covered parts of the image are at least ' + required + ':1.', code);
                 } else {


### PR DESCRIPTION
The contrast checker assumes an alpha transparency of 1, which can cause false positives on contrast checks.  Until it knows how to process alpha transparency, just mark it as a warning for manual review.
