### PR TITLE
Delete the H44.NotFormControl case

### DIFF
--- a/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_3/1_3_1.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_3/1_3_1.js
@@ -129,11 +129,6 @@ var HTMLCS_WCAG2AAA_Sniffs_Principle1_Guideline1_3_1_3_1 = {
                             var code  = 'H44.NonExistentFragment';
                         }
                         HTMLCS.addMessage(level, labels[i], msg, code);
-                    } else {
-                        var nodeName = refNode.nodeName.toLowerCase();
-                        if ((nodeName !== 'input') && (nodeName !== 'select') && (nodeName !== 'textarea')) {
-                            HTMLCS.addMessage(HTMLCS.ERROR, labels[i], 'This label\'s "for" attribute contains an ID that points to an element that is not a form control.', 'H44.NotFormControl');
-                        }
                     }
                 }
             } else {


### PR DESCRIPTION
The H44 test procedure (http://www.w3.org/TR/WCAG20-TECHS/H44) tells to verify each input, select and textarea elements, to check :
- if there is a label before the element
- if the for attribute of THIS label identify the element,
- this label must be visible

There is no rule checking that all labels must have a for attribute identifying an input element.
That's why the sniffer should not check the H44.NotFormControl