### PR TITLE
fix: undefined body dies with undefined is not an object (evaluating …

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -10,6 +10,12 @@ HTML_CodeSniffer is released under a BSD-style licence. For more information, pl
 
 HTML_CodeSniffer comes with standards and sniffs that cover the three conformance levels of the W3C [Web Content Accessibility Guidelines (WCAG) 2.0](http://www.w3.org/TR/WCAG20), and the U.S. [Section 508](http://section508.gov/index.cfm?fuseAction=stdsdoc) legislation.
 
+## I want to develop something using HTML_CodeSniffer - which branch should I use?
+
+The `master` branch is the main development branch.
+
+The `2.0` branch is the current stable branch. Builds of the Accessibility Auditor occur off this branch (starting from version 2.0.6). If you are developing a tool based off HTML_CodeSniffer, it's probably best to use the appropriate version tags, or pin your version of HTML_CodeSniffer to the `2.0` branch.
+
 ## Contributing and reporting issues
 
 To report any issues with using HTML_CodeSniffer, please use the [HTML_CodeSniffer Issue Tracker](http://github.com/squizlabs/HTML_CodeSniffer/issues).

--- a/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_4/1_4_3_Contrast.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_4/1_4_3_Contrast.js
@@ -29,7 +29,7 @@ var HTMLCS_WCAG2AAA_Sniffs_Principle1_Guideline1_4_1_4_3_Contrast = {
             var node = toProcess.shift();
 
             // This is an element.
-            if ((node.nodeType === 1) && (HTMLCS.util.isHidden(node) === false) && (HTMLCS.util.isDisabled(node) === false)) {
+            if (node && (node.nodeType === 1) && (HTMLCS.util.isHidden(node) === false) && (HTMLCS.util.isDisabled(node) === false)) {
                 var processNode = false;
                 for (var i = 0; i < node.childNodes.length; i++) {
                     // Load up new nodes, but also only process this node when


### PR DESCRIPTION
in case of the `body` not defined, this sniff dies with
```
'undefined' is not an object (evaluating 'node.nodeType')
```
This PR fixes this.