### PR TITLE
Fix `.jshintrc` file path

### DIFF
--- a/Contrib/Grunt/gruntfile.coffee
+++ b/Contrib/Grunt/gruntfile.coffee
@@ -20,7 +20,7 @@ module.exports = (grunt)->
             'Standards/**/*.js'
             'HTMLCS.js'
             'PhantomJS/runner.js'
-            'Auditor/HTMLCSAuditor.js'            
+            'Auditor/HTMLCSAuditor.js'
           ]
 
     copy:

--- a/Contrib/Grunt/gruntfile.coffee
+++ b/Contrib/Grunt/gruntfile.coffee
@@ -4,7 +4,7 @@ module.exports = (grunt)->
 
     jshint: 
       options: 
-        jshintrc: 'Integration/Grunt/.jshintrc'
+        jshintrc: 'Contrib/Grunt/.jshintrc'
 
       all: [
         'Standards/**/*.js'


### PR DESCRIPTION
Apparently, the `Integration` directory has been renamed to `Contrib`.