### PR TITLE
Register sniffer: Improve control flow graph

### DIFF
--- a/HTMLCS.js
+++ b/HTMLCS.js
@@ -232,7 +232,7 @@ var HTMLCS = new function()
                 var tagName = element.tagName.toLowerCase();
             }
 
-            // First check whether any "top" messages need to be shifted off for this
+            // First check whether any "top" messages need to be shifted off for this
             // element. If so, dump off into the main messages.
             for (var i = 0; i < topMsgs.length;) {
                 if (element === topMsgs[i].element) {

--- a/HTMLCS.js
+++ b/HTMLCS.js
@@ -443,9 +443,7 @@ var HTMLCS = new function()
         // Call the register method of the sniff, it should return an array of tags.
         if (sniffObj.register) {
             var watchedTags = sniffObj.register();
-        }
 
-        if (watchedTags && watchedTags.length > 0) {
             for (var i = 0; i < watchedTags.length; i++) {
                 if (!_tags[watchedTags[i]]) {
                     _tags[watchedTags[i]] = [];

--- a/README.markdown
+++ b/README.markdown
@@ -10,6 +10,12 @@ HTML_CodeSniffer is released under a BSD-style licence. For more information, pl
 
 HTML_CodeSniffer comes with standards and sniffs that cover the three conformance levels of the W3C [Web Content Accessibility Guidelines (WCAG) 2.0](http://www.w3.org/TR/WCAG20), and the U.S. [Section 508](http://section508.gov/index.cfm?fuseAction=stdsdoc) legislation.
 
+## I want to develop something using HTML_CodeSniffer - which branch should I use?
+
+The `master` branch is the main development branch.
+
+The `2.0` branch is the current stable branch. Builds of the Accessibility Auditor occur off this branch (starting from version 2.0.6). If you are developing a tool based off HTML_CodeSniffer, it's probably best to use the appropriate version tags, or pin your version of HTML_CodeSniffer to the `2.0` branch.
+
 ## Contributing and reporting issues
 
 To report any issues with using HTML_CodeSniffer, please use the [HTML_CodeSniffer Issue Tracker](http://github.com/squizlabs/HTML_CodeSniffer/issues).


### PR DESCRIPTION
Instead of creating the `watchedTags` variable sometimes and then test
if it exists, we can do all the work behind a single `if` statement.