### PR TITLE
Partial support for role="presentation"

### DIFF
--- a/HTMLCS.js
+++ b/HTMLCS.js
@@ -1436,6 +1436,24 @@ var HTMLCS = new function()
             // Build the column and row headers that we expect.
             return cells;
         };
+
+        /**
+         * Check if the given element is exposed to the browser accessibility
+         * API. It is not if `role="presentation"` is declared on the element or
+         * on one of its parents.
+         *
+         * See http://www.w3.org/TR/wai-aria/roles#presentation.
+         */
+        this.isExposedToTheBrowserAccessibilityAPI = function(element) {
+            do {
+                if (element.hasAttribute('role') &&
+                    element.getAttribute('role') === 'presentation') {
+                    return false;
+                }
+            } while (element = element.parentElement);
+
+            return true;
+        };
     };
 
 };

--- a/README.markdown
+++ b/README.markdown
@@ -10,6 +10,12 @@ HTML_CodeSniffer is released under a BSD-style licence. For more information, pl
 
 HTML_CodeSniffer comes with standards and sniffs that cover the three conformance levels of the W3C [Web Content Accessibility Guidelines (WCAG) 2.0](http://www.w3.org/TR/WCAG20), and the U.S. [Section 508](http://section508.gov/index.cfm?fuseAction=stdsdoc) legislation.
 
+## I want to develop something using HTML_CodeSniffer - which branch should I use?
+
+The `master` branch is the main development branch.
+
+The `2.0` branch is the current stable branch. Builds of the Accessibility Auditor occur off this branch (starting from version 2.0.6). If you are developing a tool based off HTML_CodeSniffer, it's probably best to use the appropriate version tags, or pin your version of HTML_CodeSniffer to the `2.0` branch.
+
 ## Contributing and reporting issues
 
 To report any issues with using HTML_CodeSniffer, please use the [HTML_CodeSniffer Issue Tracker](http://github.com/squizlabs/HTML_CodeSniffer/issues).

--- a/Standards/Section508/ruleset.js
+++ b/Standards/Section508/ruleset.js
@@ -31,8 +31,8 @@ window.HTMLCS_Section508 = {
         'P'
     ],
     getMsgInfo: function(code) {
-        var msgCodeParts  = code.split('.', 3);
-        var paragraph     = msgCodeParts[1].toLowerCase();
+        var msgCodeParts = code.split('.', 3);
+        var paragraph    = msgCodeParts[1].toLowerCase();
 
         var retval = [
             ['Section', '1194.22 (' + paragraph + ')']

--- a/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_1/1_1_1.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_1/1_1_1.js
@@ -138,6 +138,10 @@ var HTMLCS_WCAG2AAA_Sniffs_Principle1_Guideline1_1_1_1_1 = {
         for (var el = 0; el < elements.length; el++) {
             var element = elements[el];
 
+            if (false === HTMLCS.util.isExposedToTheBrowserAccessibilityAPI(element)) {
+                continue;
+            }
+
             var nodeName      = element.nodeName.toLowerCase();
             var linkOnlyChild = false;
             var missingAlt    = false;

--- a/Standards/WCAG2AAA/Sniffs/Principle4/Guideline4_1/4_1_2.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle4/Guideline4_1/4_1_2.js
@@ -298,8 +298,7 @@ var HTMLCS_WCAG2AAA_Sniffs_Principle4_Guideline4_1_4_1_2 = {
                     msgNodeType = nodeName.substr(6) + ' input element';
                 }
 
-                var msg = 'This ' + msgNodeType + ' does not have a value available to an accessibility API.';
-                
+                var msg       = 'This ' + msgNodeType + ' does not have a value available to an accessibility API.';
                 var builtAttr = '';
                 var warning   = false;
                 if (requiredValue === '_content') {

--- a/Standards/WCAG2AAA/Sniffs/Principle4/Guideline4_1/4_1_2.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle4/Guideline4_1/4_1_2.js
@@ -92,6 +92,10 @@ var HTMLCS_WCAG2AAA_Sniffs_Principle4_Guideline4_1_4_1_2 = {
         for (var el = 0; el < elements.length; el++) {
             var element = elements[el];
 
+            if (false === HTMLCS.util.isExposedToTheBrowserAccessibilityAPI(element)) {
+                continue;
+            }
+
             var nameFound = false;
             var hrefFound = false;
             var content   = HTMLCS.util.getElementTextContent(element);


### PR DESCRIPTION
Partially fix https://github.com/squizlabs/HTML_CodeSniffer/issues/149.

In 2 steps:
  1. We add the `HTMLCS.util.isExposedToTheBrowserAccessibilityAPI` function,
  2. When necessary, we use this function.

The “when necessary” part is tricky. Actually, one may use HTMLCS to add its own validation rules that are not related to accessibility, so we **cannot** apply the `HTMLCS.util.isExposedToTheBrowserAccessibilityAPI` function globally (in `HTMLCS._processSniffs` for instance). Instead, we have to check where the role presentation may interfer with an accessility rule. I would say it interfers with all accessibility rules. Consequently, this PR is a first step. The next step is to add this check into all rules.

Thoughts?