### PR TITLE
FIX Remove trailing url parameters

### DIFF
--- a/HTMLCS.js
+++ b/HTMLCS.js
@@ -494,6 +494,9 @@ var HTMLCS = new function()
 					// We have found our appropriate <script> tag that includes
 					// this file, we can extract the path.
 					path = scripts[i].src.replace(/HTMLCS\.js/,'');
+
+					// trim any trailing bits
+					path = path.substring(0, path.indexOf('?'));
 					break;
 				}
 			}


### PR DESCRIPTION
Before including rulesets / sniffs, strip any query string params from the current JS file's URL. 