### PR TITLE
WCAG Guideline 4.1.2 (H91) shouldn't apply to input[type=hidden] elements

### DIFF
--- a/Standards/WCAG2AAA/Sniffs/Principle4/Guideline4_1/4_1_2.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle4/Guideline4_1/4_1_2.js
@@ -199,7 +199,7 @@ _global.HTMLCS_WCAG2AAA_Sniffs_Principle4_Guideline4_1_4_1_2 = {
             var requiredValue = requiredValues[nodeName];
 
             // Any element that doesn't have specific handling must have content.
-            if (!matchingRequiredNames) {
+            if (!matchingRequiredNames && nodeName !== 'input_hidden') {
                 matchingRequiredNames = ['_content'];
             }
 


### PR DESCRIPTION
Issue presents when running HTML_CodeSniffer via node against HTML snippet (browser auditor GUI doesn't collect `type=hidden` nodes for sniffing since they're usually `display:none`).

For the HTML snippet `<input type="hidden" name="option_list" value="" class="js-option-list">`, the current build of the command-line sniffer flags the following error:

> [HTMLCS] ERROR|WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.InputHidden.Name|input||This hidden input element does not have a name available to an accessibility API. Valid names are: element content.|<input type="hidden" name="option_list" value="" class="js-option-list">

Basically, hidden elements are falling into the catch-all check for unknown-type input elements needing to be described by their content. Since that seemed like a valid check against nodes with unspecified `type`, this fix exempts `type=hidden` nodes from that fallback. While technically a `type=hidden` node is not included in the accessibility tree because of  `display:none`, I'm of the opinion that this exemption is valid because the [html5 spec](https://www.w3.org/TR/html5/forms.html#hidden-state-(type=hidden)) cites hidden-type as "The input element represents a value that is not intended to be examined or manipulated by the user."

---

To reproduce:

git clone, `npm install`, `grunt build`, `npm install jsdom` then run this with node -

```js
var jsdom    = require('jsdom'),fs = require('fs');

var vConsole = jsdom.createVirtualConsole();
vConsole.on('log', function(message) {console.log(message)})

jsdom.env({
    html: '<input type="hidden" name="option_list" value="" class="js-option-list">',
    src: [fs.readFileSync('./build/HTMLCS.js')],
    virtualConsole: vConsole,
    done: function (err, window) {
        window.HTMLCS_RUNNER.run('WCAG2AA');
    }
});
```

tested in node v4.4.3