### PR TITLE
Fixing eroneous bad id for labels with no for attribute

### DIFF
--- a/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_3/1_3_1.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_3/1_3_1.js
@@ -130,7 +130,7 @@ _global.HTMLCS_WCAG2AAA_Sniffs_Principle1_Guideline1_3_1_3_1 = {
 		this._labelNames = {};
 		var labels = top.getElementsByTagName('label');
 		for (var i = 0; i < labels.length; i++) {
-			if ((labels[i].getAttribute('for') !== null) || (labels[i].getAttribute('for') !== '')) {
+			if ((labels[i].getAttribute('for') !== null) && (labels[i].getAttribute('for') !== '')) {
 				var labelFor = labels[i].getAttribute('for');
 				if ((this._labelNames[labelFor]) && (this._labelNames[labelFor] !== null)) {
 					this._labelNames[labelFor] = null;


### PR DESCRIPTION
a bad if statement meant we always checked a for's id even when the for was missing.