### PR TITLE
Fix a rowspan edge case

### DIFF
--- a/HTMLCS.Util.js
+++ b/HTMLCS.Util.js
@@ -1111,8 +1111,7 @@ _global.HTMLCS.util = function() {
                     if (thisCell.nodeType === 1) {
                         // Skip columns that are skipped due to rowspan.
                         if (skipCells[rownum]) {
-                            while (skipCells[rownum][0] === colnum) {
-                                skipCells[rownum].shift();
+                            while (skipCells[rownum][colnum]) {
                                 colnum++;
                             }
                         }
@@ -1130,7 +1129,7 @@ _global.HTMLCS.util = function() {
                                 }
 
                                 for (var j = colnum; j < colnum + colspan; j++) {
-                                    skipCells[i].push(j);
+                                    skipCells[i][j] = true;
                                 }
                             }
                         }

--- a/Tests/WCAG2/1_3_1_Table_Header_Attr.html
+++ b/Tests/WCAG2/1_3_1_Table_Header_Attr.html
@@ -6,6 +6,7 @@
 Name: SC 1.3.1 Table Heading Attributes
 Standard: WCAG2AAA
 Assert: No Error *.H43.IncorrectAttr on #correctTableHeaders
+Assert: No Error *.H43.IncorrectAttr on #correctTableHeadersComplexRowspan
 -->
 </head>
 <body>
@@ -40,6 +41,66 @@ Assert: No Error *.H43.IncorrectAttr on #correctTableHeaders
                 </div>
             </td>
         </tr>
+    </table>
+
+    <table id="correctTableHeadersComplexRowspan">
+        <thead>
+            <tr>
+                <th rowspan="2" id="h1-0"></th>
+                <th colspan="5" id="h1-1-5">long header</th>
+                <th rowspan="2" id="h1-6">last header</th>
+            </tr>
+            <tr>
+                <th id="h2-1">sub1</th>
+                <th id="h2-2">sub2</th>
+                <th id="h2-3">sub3</th>
+                <th id="h2-4">sub4</th>
+                <th id="h2-5">sub5</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td rowspan="2" headers="h1-0">1.0</td>
+                <td headers="h13-1-5 h2-1">1.1.1</td>
+                <td headers="h1-1-5 h2-2">1.2.1</td>
+                <td headers="h1-1-5 h2-3">1.3.1</td>
+                <td headers="h1-1-5 h2-4">1.4.1</td>
+                <td headers="h1-1-5 h2-5">1.5.1</td>
+                <td rowspan="2" headers="h1-6">1.6</td>
+            </tr>
+            <tr>
+                <td headers="h1-1-5 h2-1">1.1.2</td>
+                <td headers="h1-1-5 h2-2">1.2.2</td>
+                <td headers="h1-1-5 h2-3">1.3.2</td>
+                <td headers="h1-1-5 h2-4">1.4.2</td>
+                <td headers="h1-1-5 h2-5">1.5.2</td>
+            </tr>
+            <tr>
+                <td rowspan="2" headers="h1-0">2.0</td>
+                <td headers="h1-1-5 h2-1">2.1.1</td>
+                <td headers="h1-1-5 h2-2">2.2.1</td>
+                <td headers="h1-1-5 h2-3">2.3.1</td>
+                <td headers="h1-1-5 h2-4">2.4.1</td>
+                <td headers="h1-1-5 h2-5">2.5.1</td>
+                <td rowspan="2" headers="h1-6">2.6</td>
+            </tr>
+            <tr>
+                <td headers="h1-1-5 h2-1">2.1.2</td>
+                <td headers="h1-1-5 h2-2">2.2.2</td>
+                <td headers="h1-1-5 h2-3">2.3.2</td>
+                <td headers="h1-1-5 h2-4">2.4.2</td>
+                <td headers="h1-1-5 h2-5">2.5.2</td>
+            </tr>
+            <tr>
+                <td rowspan="2" headers="h1-0">3.0</td>
+                <td headers="h1-1-5 h2-1">3.1</td>
+                <td headers="h1-1-5 h2-2">3.2</td>
+                <td headers="h1-1-5 h2-3">3.3</td>
+                <td headers="h1-1-5 h2-4">3.4</td>
+                <td headers="h1-1-5 h2-5">3.5</td>
+                <td rowspan="2" headers="h1-6">3.6</td>
+            </tr>
+        </tbody>
     </table>
 </body>
 </html>


### PR DESCRIPTION
If you have a table where one a cell on one column - other than the last column - has a `rowspan` greater than 1, and on the same row, the column in the last cell *also* has a `rowspan` greater than 1, the tool gets confused about which cells to "skip" when it's figuring out which headers the cells should have.

It's related to the `skipCells` variable never having the last column removed.  Because `getCellHeaders` looks at all the cells twice - once for `th` and again for `td` - then `skipCells` begins with incorrect information on the second iteration.

![example table](https://user-images.githubusercontent.com/1775733/43554723-a45c438a-95bb-11e8-84a5-286b862cc215.png)

In this example table, `skipCells` begins the second iteration like this:

```js
[
  1: [ 6 ],
  3: [ 6 ]
]
```

Now as it checks for rowspans to see what to skip, when it scans row 0 it will find two cells with `rowspan=2`, and now `skipCells` looks like this:

```js
[
  1: [ 6, 0, 6 ]
  3: [ 6 ]
]
```

With that, the [conditional on line 1114](https://github.com/squizlabs/HTML_CodeSniffer/compare/master...18F:multiple-row-spans?expand=1#diff-0107b3d0ad748849539179a413307547L1114) will ***not*** be true on row 1, column 0, even though it should be.

The ultimate result is that the tool ends up with the wrong list of expected `td` headers and reports a lot of false positives on big tables.

My solution was to build a `true`/`false` skip lookup table instead of trying to only keep track of the next column to skip on a given row.  This seems to have done the trick.  😄

Is there a test suite I should run to make sure I haven't broken anything?