### PR TITLE
Use prepack to build artifacts which are needed with npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ package-lock.json
 build/
 node_modules/
 Auditor/Auditor_with_beacon.js
+*.tgz
 
 # OS generated files #
 ######################

--- a/package.json
+++ b/package.json
@@ -7,8 +7,19 @@
     "htmlcs"
   ],
   "scripts": {
+    "prepack": "grunt build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "files": [
+    "Auditor",
+    "build",
+    "Contrib",
+    "Standards",
+    "Translations",
+    "HTMLCS.js",
+    "HTMLCS.Util.js",
+    "index.js"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/squizlabs/HTML_CodeSniffer.git"
@@ -18,14 +29,12 @@
     "url": "https://github.com/squizlabs/HTML_CodeSniffer/issues"
   },
   "homepage": "http://squizlabs.github.io/HTML_CodeSniffer/",
-  "dependencies": {
-    "grunt": "^1.0.0",
-    "grunt-contrib-copy": "^1.0.0",
-    "grunt-contrib-jshint": "^1.0.0",
-    "grunt-contrib-watch": "^1.0.0",
-    "load-grunt-tasks": "^3.5.2"
-  },
   "devDependencies": {
-    "grunt-contrib-uglify": "^2.3.0"
+    "grunt": "^1.0.3",
+    "grunt-contrib-copy": "^1.0.0",
+    "grunt-contrib-jshint": "^2.0.0",
+    "grunt-contrib-watch": "^1.1.0",
+    "load-grunt-tasks": "^4.0.0",
+    "grunt-contrib-uglify": "^4.0.0"
   }
 }


### PR DESCRIPTION
Added `prepack` command which builds just before publishing, hence making the `build` folder available when doing `npm install html_codesniffer`.

Updated dependencies and moved them all to `devDependencies` since they are only needed on development phase.