### PR TITLE
Fixes AMD header

### DIFF
--- a/Contrib/Build/umd-header.js
+++ b/Contrib/Build/umd-header.js
@@ -12,7 +12,7 @@
  */
 (function (root, factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['htmlcs'], factory);
+        define('htmlcs', factory);
     } else if (typeof exports === 'object') {
         module.exports = factory();
     } else {


### PR DESCRIPTION
The current AMD header is defining an anonymouse module, which you can't then `require` to then use that module