### PR TITLE
Set bg color of strong element to transparent

### DIFF
--- a/Auditor/HTMLCSAuditor.css
+++ b/Auditor/HTMLCSAuditor.css
@@ -1029,6 +1029,7 @@
 }
 
 #HTMLCS-wrapper .HTMLCS-tile-text > strong {
+    background: transparent;
     font-size: 1.7em;
     color: #FFF;
     display: block;


### PR DESCRIPTION
Fixed issue where the background color of a strong element inherited from a parent site was causing a contrast issue.

Before:
<img width="330" alt="Screen Shot 2019-09-03 at 9 04 28 AM" src="https://user-images.githubusercontent.com/459581/64175741-f3c0f180-ce29-11e9-8131-ba101d4a4bbf.png">

After:
<img width="316" alt="Screen Shot 2019-09-03 at 9 05 40 AM" src="https://user-images.githubusercontent.com/459581/64175770-06d3c180-ce2a-11e9-9ef0-002b50293ce7.png">

This was happening on my personal site: timwright.org