### PR TITLE
Deal with refNode being set to null in 2_5_3

### DIFF
--- a/Standards/WCAG2AAA/Sniffs/Principle2/Guideline2_5/2_5_3.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle2/Guideline2_5/2_5_3.js
@@ -55,13 +55,16 @@ _global.HTMLCS_WCAG2AAA_Sniffs_Principle2_Guideline2_5_2_5_3 = {
             case "label":
                 visibleLabel = HTMLCS.util.getTextContent(element);
                 var labelFor = element.getAttribute("for");
+                var refNode = undefined;
                 if (labelFor) {
                     if (top.ownerDocument) {
-                        var refNode = top.ownerDocument.getElementById(labelFor);
+                        refNode = top.ownerDocument.getElementById(labelFor);
                     } else {
-                        var refNode = top.getElementById(labelFor);
+                        refNode = top.getElementById(labelFor);
                     }
-                    accessibleName = HTMLCS.util.getAccessibleName(refNode);
+                    if (!!refNode) {
+                        accessibleName = HTMLCS.util.getAccessibleName(refNode);
+                    }
                 }
                 break;
             case "input":


### PR DESCRIPTION
The label might refer to a non-existing element - this currently blows up the checker as refNode will be set to null.