### PR TITLE
WIP: Make sure to throw an error when no translation is found

### DIFF
--- a/HTMLCS.js
+++ b/HTMLCS.js
@@ -81,11 +81,19 @@ _global.HTMLCS = new function()
      * @return {String}
      */
     this.getTranslation = function(text) {
-        try {
-            return _global.translation[this.lang][text];
-        } catch (e) {
+        var translations = _global.translation[this.lang];
+
+        if (!translations) {
+            throw new Error ('Missing translations for language ' + this.lang);
+        }
+
+        var translation = translations[text];
+
+        if (!translation) {
             throw new Error('Translation for "' + text + '" does not exist in current language ' + this.lang);
         }
+
+        return translation;
     };
 
     /**


### PR DESCRIPTION
**What does this PR solve?**
It propagates the translation error when a translation isn't found for a given key (or if the language doesn't exist).

My colleague and I ran into this issue today while running pa11y where a missing translation resulted in an `Uncaught TypeError: Cannot read property 'replace' of undefined` from this package. I think this should take care of it, so we would get the right error propagated instead :)

My colleague created a [minimal-reproduction-repo](https://bitbucket.org/apdrsn/pa11y-error/) where you can see the error. If you use `npm link` to link HTML_CodeSniffer to this branch instead you can see the actual translation error getting propagated.

The weird thing though is that the specific key (`1_3_5_H98.InvalidAutoComplete_Text`) it complained about isn't missing in the translation file (`en.js`). I haven't had the time to look into that bit, but this get us halfway there :)
