### PR TITLE
Don't throw an error when missing a translation - just log

### DIFF
--- a/HTMLCS.js
+++ b/HTMLCS.js
@@ -84,13 +84,15 @@ _global.HTMLCS = new function()
         var translations = _global.translation[this.lang];
 
         if (!translations) {
-            throw new Error ('Missing translations for language ' + this.lang);
+            console.error('Missing translations for language ' + this.lang);
+            return '';
         }
 
         var translation = translations[text];
 
         if (!translation) {
-            throw new Error('Translation for "' + text + '" does not exist in current language ' + this.lang);
+            console.error('Translation for "' + text + '" does not exist in current language ' + this.lang);
+            return '';
         }
 
         return translation;


### PR DESCRIPTION
*This is a suggestion*

If an error is thrown the whole program breaks. This combined with the fact that some keys are missing across different translations makes it a fairly inconvenient issue.

With this in place the program would finish with logs warning about the missing keys.

Right now I think the only key missing in `translation.en` is `4_1_2_attribute`. If that is added this implementation could fallback to using the english translation as default (so it would still give somewhat valuable information to the user). It could also just return the key that was passed to `getTranslation` - that way the user would always get some useful information no matter what. That could easily be included in this pull request.

I don't know what the text for `4_1_2_attribute` should be but would be happy to include that as well.
